### PR TITLE
Rename Error.name to Error.code

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ request({
         timeout: 5000
     }, (error, response, body) => {
         if (error) {
-            if (error.name === 'CircuitBreakerOpenException') {
+            if (error.code === 'CircuitBreakerOpenException') {
                 console.log('Downstream service is curcuit broken');
             } else {
                 console.log('Something went humpty dumpty');

--- a/lib/error.js
+++ b/lib/error.js
@@ -3,7 +3,7 @@
 class CircuitBreakerOpenExceptionError extends Error {
     constructor(message) {
         super(message);
-        this.name = 'CircuitBreakerOpenException';
+        this.code = 'CircuitBreakerOpenException';
         this.message = message || '';
     }
 }

--- a/test/integration/utils.js
+++ b/test/integration/utils.js
@@ -64,7 +64,7 @@ const clientHttp = (options) => {
         });
 
         req.on('error', (error) => {
-            if (error.name === 'CircuitBreakerOpenException') {
+            if (error.code === 'CircuitBreakerOpenException') {
                 resolve('circuit breaking');
             } else {
                 resolve('error');
@@ -105,7 +105,7 @@ const clientRequest = (options) => {
         });
 
         req.on('error', (error) => {
-            if (error.name === 'CircuitBreakerOpenException') {
+            if (error.code === 'CircuitBreakerOpenException') {
                 resolve('circuit breaking');
             } else if (error.code === 'ESOCKETTIMEDOUT') {
                 resolve('timeout');


### PR DESCRIPTION
Rename `Error.name` which holds the `CircuitBreakerOpenException` value to `Error.code`. This is mostly to cater for http modules, like `node-fetch` which alter the Error objects which buble up.