### PR TITLE
Rearranged event order

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -8,6 +8,8 @@ const abslog = require('abslog');
 const Breaker = require('./breaker');
 const errors = require('./error');
 
+const hook = Symbol('_hook');
+
 const CircuitB = class CircuitB extends EventEmitter {
     constructor({
         maxFailures = 5, maxAge = 5000, timeout = 20000, logger = undefined,
@@ -43,136 +45,152 @@ const CircuitB = class CircuitB extends EventEmitter {
             value: abslog(logger),
         });
 
-        const hooks = {
-            init: (asyncId, type, triggerAsyncId, resource) => {
-                if (type === 'TCPWRAP') {
-                    process.nextTick(() => {
-                        let tripped = false;
-                        let breaker;
-                        let timer;
-
-                        // "lookup" happens before net connect, everything after this is
-                        // too late to be used to prevent that a net connection is made.
-                        resource.owner.once('lookup', (err, address, family, host) => {
-                            if (this.registry.has(host)) {
-                                breaker = this.registry.get(host);
-                                if (breaker.check()) {
-                                    this.log.debug('Circuit breaker is open', breaker.host, asyncId);
-                                    resource.owner.destroy(new errors.CircuitBreakerOpenExceptionError(`Circuit breaker is open for host: ${breaker.host}`));
-                                    return;
-                                }
-
-                                timer = setTimeout(() => {
-                                    this.log.debug('Circuit breaker triggered timeout', breaker.host, asyncId);
-                                    resource.owner.destroy(new errors.CircuitBreakerTimeoutError(`Circuit breaker triggered timed out for host: ${breaker.host}`));
-                                }, breaker.timeout);
-                            }
-                        });
-
-                        resource.owner.once('error', (error) => {
-                            if (tripped) {
-                                return;
-                            }
-
-                            if (timer) {
-                                clearTimeout(timer);
-                            }
-
-                            if (breaker) {
-                                this.log.debug('Circuit breaker got "error" event on resource', breaker.host, asyncId);
-                                if (error instanceof errors.CircuitBreakerOpenExceptionError) {
-                                    return;
-                                }
-
-                                tripped = breaker.trip();
-                            }
-                        });
-
-                        resource.owner.once('timeout', () => {
-                            if (tripped) {
-                                return;
-                            }
-
-                            if (timer) {
-                                clearTimeout(timer);
-                            }
-
-                            if (breaker) {
-                                this.log.debug('Circuit breaker got "timeout" event on resource', breaker.host, asyncId);
-                                tripped = breaker.trip();
-                            }
-                        });
-
-                        resource.owner.once('abort', () => {
-                            if (tripped) {
-                                return;
-                            }
-
-                            if (breaker) {
-                                this.log.debug('Circuit breaker got "abort" event on resource', breaker.host, asyncId);
-                                tripped = breaker.trip();
-                            }
-                        });
-
-                        resource.owner.once('data', () => {
-                            if (timer) {
-                                clearTimeout(timer);
-                            }
-
-                            if (breaker) {
-                                this.log.debug('Circuit breaker got "data" event on resource', breaker.host, asyncId);
-                            }
-                        });
-
-                        resource.owner.once('end', () => {
-                            if (tripped) {
-                                return;
-                            }
-
-                            if (timer) {
-                                clearTimeout(timer);
-                            }
-
-                            if (breaker) {
-                                // eslint-disable-next-line no-underscore-dangle
-                                const httpMsg = resource.owner._httpMessage;
-
-                                if (!httpMsg || !httpMsg.res) {
-                                    this.log.debug('Circuit breaker got "end" event on resource - "http message" is missing', breaker.host, asyncId);
-                                    tripped = breaker.trip();
-                                    return;
-                                }
-
-                                const code = httpMsg.res.statusCode;
-
-                                if (code >= 400 && code <= 499) {
-                                    this.log.debug('Circuit breaker got "end" event on resource - http status is 4xx', breaker.host, asyncId);
-                                    tripped = breaker.trip();
-                                    return;
-                                }
-
-                                if (code >= 500 && code <= 599) {
-                                    this.log.debug('Circuit breaker got "end" event on resource - http status is 5xx', breaker.host, asyncId);
-                                    tripped = breaker.trip();
-                                    return;
-                                }
-
-                                this.log.debug('Circuit breaker got "end" event on resource - http status is 2xx', breaker.host, asyncId);
-                                breaker.reset();
-                            }
-                        });
-                    });
-                }
-            },
-        };
-
         Object.defineProperty(this, 'hook', {
-            value: asyncHooks.createHook(hooks),
+            value: asyncHooks.createHook({
+                init: this[hook].bind(this),
+            }),
         });
     }
 
     get [Symbol.toStringTag]() {
         return 'CircuitB';
+    }
+
+    [hook](asyncId, type, triggerAsyncId, resource) {
+        if (type !== 'TCPWRAP') {
+            return;
+        }
+
+        process.nextTick(() => {
+            // "lookup" happens before net connect, everything after this is
+            // too late to be used to prevent that a net connection is made.
+            resource.owner.once('lookup', (err, address, family, host) => {
+                this.log.trace('==================================', asyncId);
+                if (this.registry.has(host)) {
+                    const breaker = this.registry.get(host);
+                    let tripped = false;
+
+                    this.log.trace('Circuit breaker has host', breaker.host, asyncId);
+
+                    if (breaker.check()) {
+                        this.log.debug('Circuit breaker is open', breaker.host, asyncId);
+                        resource.owner.destroy(new errors.CircuitBreakerOpenExceptionError(`Circuit breaker is open for host: ${breaker.host}`));
+                        return;
+                    }
+
+                    let timer = setTimeout(() => {
+                        this.log.debug('Circuit breaker triggered timeout', breaker.host, asyncId);
+                        resource.owner.destroy(new errors.CircuitBreakerTimeoutError(`Circuit breaker triggered timed out for host: ${breaker.host}`));
+                    }, breaker.timeout);
+
+                    resource.owner.once('error', (error) => {
+                        if (tripped) {
+                            this.log.trace('Circuit breaker tripped in "error" event', breaker.host, asyncId);
+                            return;
+                        }
+
+                        if (timer) {
+                            this.log.trace('Circuit breaker clear timeout in "error" event', breaker.host, asyncId);
+                            clearTimeout(timer);
+                            timer = null;
+                        }
+
+                        if (breaker) {
+                            if (error instanceof errors.CircuitBreakerOpenExceptionError) {
+                                this.log.debug('Circuit breaker got "CircuitBreakerOpenExceptionError" event on resource', breaker.host, asyncId);
+                                return;
+                            }
+
+                            this.log.debug('Circuit breaker got "error" event on resource', breaker.host, asyncId);
+                            tripped = breaker.trip();
+                        }
+                    });
+
+                    resource.owner.once('timeout', () => {
+                        if (tripped) {
+                            this.log.trace('Circuit breaker tripped in "timeout" event', breaker.host, asyncId);
+                            return;
+                        }
+
+                        if (timer) {
+                            this.log.trace('Circuit breaker clear timeout in "timeout" event', breaker.host, asyncId);
+                            clearTimeout(timer);
+                            timer = null;
+                        }
+
+                        if (breaker) {
+                            this.log.debug('Circuit breaker got "timeout" event on resource', breaker.host, asyncId);
+                            tripped = breaker.trip();
+                        }
+                    });
+
+                    resource.owner.once('abort', () => {
+                        if (tripped) {
+                            this.log.trace('Circuit breaker tripped in "abort" event', breaker.host, asyncId);
+                            return;
+                        }
+
+                        if (breaker) {
+                            this.log.debug('Circuit breaker got "abort" event on resource', breaker.host, asyncId);
+                            tripped = breaker.trip();
+                        }
+                    });
+
+                    resource.owner.once('data', () => {
+                        if (timer) {
+                            this.log.trace('Circuit breaker clear timeout in "data" event', breaker.host, asyncId);
+                            clearTimeout(timer);
+                            timer = null;
+                        }
+
+                        if (breaker) {
+                            this.log.debug('Circuit breaker got "data" event on resource', breaker.host, asyncId);
+                        }
+                    });
+
+                    resource.owner.once('end', () => {
+                        if (tripped) {
+                            this.log.trace('Circuit breaker tripped in "end" event', breaker.host, asyncId);
+                            return;
+                        }
+
+                        if (timer) {
+                            this.log.trace('Circuit breaker clear timeout in "end" event', breaker.host, asyncId);
+                            clearTimeout(timer);
+                            timer = null;
+                        }
+
+                        if (breaker) {
+                            // eslint-disable-next-line no-underscore-dangle
+                            const httpMsg = resource.owner._httpMessage;
+
+                            if (!httpMsg || !httpMsg.res) {
+                                this.log.debug('Circuit breaker got "end" event on resource - "http message" is missing', breaker.host, asyncId);
+                                tripped = breaker.trip();
+                                return;
+                            }
+
+                            const code = httpMsg.res.statusCode;
+
+                            if (code >= 400 && code <= 499) {
+                                this.log.debug('Circuit breaker got "end" event on resource - http status is 4xx', breaker.host, asyncId);
+                                tripped = breaker.trip();
+                                return;
+                            }
+
+                            if (code >= 500 && code <= 599) {
+                                this.log.debug('Circuit breaker got "end" event on resource - http status is 5xx', breaker.host, asyncId);
+                                tripped = breaker.trip();
+                                return;
+                            }
+
+                            this.log.debug('Circuit breaker got "end" event on resource - http status is 2xx', breaker.host, asyncId);
+                            breaker.reset();
+                        }
+                    });
+                }
+            });
+        });
     }
 
     enable() {


### PR DESCRIPTION
This rearranges how events is set on the resource. By doing so events is only set on resources which is not circuit broken. It also eliminates variables holding timeout from being overwritten.