### PR TITLE
Refine which http status codes to trip on

### DIFF
--- a/lib/breaker.js
+++ b/lib/breaker.js
@@ -14,9 +14,9 @@ const Breaker = class Breaker extends EventEmitter {
 
         assert(host, 'The argument "host" must be provided');
         assert(Number.isInteger(maxFailures), `Provided value, ${maxFailures}, to argument "maxFailures" is not a number`);
+        assert(utils.isFunction(onResponse), `Provided value to argument "onResponse" is not a function`);
         assert(Number.isInteger(timeout), `Provided value, ${timeout}, to argument "timeout" is not a number`);
         assert(Number.isInteger(maxAge), `Provided value, ${maxAge}, to argument "maxAge" is not a number`);
-        assert(utils.isFunction(onResponse), `Provided value to argument "onResponse" is not a function`);
 
         Object.defineProperty(this, 'host', {
             value: host,

--- a/lib/breaker.js
+++ b/lib/breaker.js
@@ -1,20 +1,22 @@
 'use strict';
 
 const EventEmitter = require('events');
-const response = require('./response');
 const Metrics = require('@metrics/client');
 const assert = require('assert');
+const response = require('./response');
 const utils = require('./utils');
 
 const stats = Symbol('_stats');
 
 const Breaker = class Breaker extends EventEmitter {
-    constructor(host = '', { maxFailures = 5, onResponse = response, maxAge = 5000, timeout = 20000 } = {}) {
+    constructor(host = '', {
+        maxFailures = 5, onResponse = response, maxAge = 5000, timeout = 20000,
+    } = {}) {
         super();
 
         assert(host, 'The argument "host" must be provided');
         assert(Number.isInteger(maxFailures), `Provided value, ${maxFailures}, to argument "maxFailures" is not a number`);
-        assert(utils.isFunction(onResponse), `Provided value to argument "onResponse" is not a function`);
+        assert(utils.isFunction(onResponse), 'Provided value to argument "onResponse" is not a function');
         assert(Number.isInteger(timeout), `Provided value, ${timeout}, to argument "timeout" is not a number`);
         assert(Number.isInteger(maxAge), `Provided value, ${maxAge}, to argument "maxAge" is not a number`);
 

--- a/lib/breaker.js
+++ b/lib/breaker.js
@@ -1,20 +1,20 @@
 'use strict';
 
 const EventEmitter = require('events');
+const response = require('./response');
 const Metrics = require('@metrics/client');
 const assert = require('assert');
 
 const stats = Symbol('_stats');
 
 const Breaker = class Breaker extends EventEmitter {
-    constructor(host = '', { maxFailures = 5, maxAge = 5000, timeout = 20000 } = {}) {
+    constructor(host = '', { maxFailures = 5, onResponse = response, maxAge = 5000, timeout = 20000 } = {}) {
         super();
 
         assert(host, 'The argument "host" must be provided');
         assert(Number.isInteger(maxFailures), `Provided value, ${maxFailures}, to argument "maxFailures" is not a number`);
         assert(Number.isInteger(timeout), `Provided value, ${timeout}, to argument "timeout" is not a number`);
         assert(Number.isInteger(maxAge), `Provided value, ${maxAge}, to argument "maxAge" is not a number`);
-
 
         Object.defineProperty(this, 'host', {
             value: host,
@@ -23,6 +23,11 @@ const Breaker = class Breaker extends EventEmitter {
 
         Object.defineProperty(this, 'timeout', {
             value: timeout,
+            enumerable: true,
+        });
+
+        Object.defineProperty(this, 'onResponse', {
+            value: onResponse,
             enumerable: true,
         });
 

--- a/lib/breaker.js
+++ b/lib/breaker.js
@@ -4,6 +4,7 @@ const EventEmitter = require('events');
 const response = require('./response');
 const Metrics = require('@metrics/client');
 const assert = require('assert');
+const utils = require('./utils');
 
 const stats = Symbol('_stats');
 
@@ -15,6 +16,7 @@ const Breaker = class Breaker extends EventEmitter {
         assert(Number.isInteger(maxFailures), `Provided value, ${maxFailures}, to argument "maxFailures" is not a number`);
         assert(Number.isInteger(timeout), `Provided value, ${timeout}, to argument "timeout" is not a number`);
         assert(Number.isInteger(maxAge), `Provided value, ${maxAge}, to argument "maxAge" is not a number`);
+        assert(utils.isFunction(onResponse), `Provided value to argument "onResponse" is not a function`);
 
         Object.defineProperty(this, 'host', {
             value: host,

--- a/lib/main.js
+++ b/lib/main.js
@@ -8,6 +8,7 @@ const assert = require('assert');
 const abslog = require('abslog');
 const Breaker = require('./breaker');
 const errors = require('./error');
+const utils = require('./utils');
 
 const hook = Symbol('_hook');
 
@@ -24,6 +25,7 @@ const CircuitB = class CircuitB extends EventEmitter {
         assert(Number.isInteger(maxFailures), `Provided value, ${maxFailures}, to argument "maxFailures" is not a number`);
         assert(Number.isInteger(timeout), `Provided value, ${timeout}, to argument "timeout" is not a number`);
         assert(Number.isInteger(maxAge), `Provided value, ${maxAge}, to argument "maxAge" is not a number`);
+        assert(utils.isFunction(onResponse), `Provided value to argument "onResponse" is not a function`);
 
         Object.defineProperty(this, 'registry', {
             value: new Map(),

--- a/lib/main.js
+++ b/lib/main.js
@@ -2,6 +2,7 @@
 
 const EventEmitter = require('events');
 const asyncHooks = require('async_hooks');
+const response = require('./response');
 const Metrics = require('@metrics/client');
 const assert = require('assert');
 const abslog = require('abslog');
@@ -12,7 +13,11 @@ const hook = Symbol('_hook');
 
 const CircuitB = class CircuitB extends EventEmitter {
     constructor({
-        maxFailures = 5, maxAge = 5000, timeout = 20000, logger = undefined,
+        maxFailures = 5,
+        onResponse = response,
+        timeout = 20000,
+        maxAge = 5000,
+        logger = undefined,
     } = {}) {
         super();
 
@@ -30,6 +35,10 @@ const CircuitB = class CircuitB extends EventEmitter {
 
         Object.defineProperty(this, 'timeout', {
             value: timeout,
+        });
+
+        Object.defineProperty(this, 'onResponse', {
+            value: onResponse,
         });
 
         Object.defineProperty(this, 'maxFailures', {
@@ -170,21 +179,13 @@ const CircuitB = class CircuitB extends EventEmitter {
                                 return;
                             }
 
-                            const code = httpMsg.res.statusCode;
-
-                            if (code >= 400 && code <= 499) {
-                                this.log.debug('Circuit breaker got "end" event on resource - http status is 4xx', breaker.host, asyncId);
+                            if (breaker.onResponse(httpMsg.res)) {
+                                this.log.debug(`Circuit breaker got "end" event on resource - http status is ${httpMsg.res.statusCode}`, breaker.host, asyncId);
                                 tripped = breaker.trip();
                                 return;
                             }
 
-                            if (code >= 500 && code <= 599) {
-                                this.log.debug('Circuit breaker got "end" event on resource - http status is 5xx', breaker.host, asyncId);
-                                tripped = breaker.trip();
-                                return;
-                            }
-
-                            this.log.debug('Circuit breaker got "end" event on resource - http status is 2xx', breaker.host, asyncId);
+                            this.log.debug(`Circuit breaker got "end" event on resource - http status is ${httpMsg.res.statusCode}`, breaker.host, asyncId);
                             breaker.reset();
                         }
                     });
@@ -205,10 +206,11 @@ const CircuitB = class CircuitB extends EventEmitter {
 
     set(host, {
         maxFailures = this.maxFailures,
-        maxAge = this.maxAge,
+        onResponse = this.onResponse,
         timeout = this.timeout,
+        maxAge = this.maxAge,
     } = {}) {
-        const breaker = new Breaker(host, { maxFailures, maxAge, timeout });
+        const breaker = new Breaker(host, { maxFailures, onResponse, maxAge, timeout });
         breaker.on('open', (hostname) => {
             this.emit('open', hostname);
         });

--- a/lib/main.js
+++ b/lib/main.js
@@ -2,10 +2,10 @@
 
 const EventEmitter = require('events');
 const asyncHooks = require('async_hooks');
-const response = require('./response');
 const Metrics = require('@metrics/client');
 const assert = require('assert');
 const abslog = require('abslog');
+const response = require('./response');
 const Breaker = require('./breaker');
 const errors = require('./error');
 const utils = require('./utils');
@@ -23,7 +23,7 @@ const CircuitB = class CircuitB extends EventEmitter {
         super();
 
         assert(Number.isInteger(maxFailures), `Provided value, ${maxFailures}, to argument "maxFailures" is not a number`);
-        assert(utils.isFunction(onResponse), `Provided value to argument "onResponse" is not a function`);
+        assert(utils.isFunction(onResponse), 'Provided value to argument "onResponse" is not a function');
         assert(Number.isInteger(timeout), `Provided value, ${timeout}, to argument "timeout" is not a number`);
         assert(Number.isInteger(maxAge), `Provided value, ${maxAge}, to argument "maxAge" is not a number`);
 
@@ -212,7 +212,9 @@ const CircuitB = class CircuitB extends EventEmitter {
         timeout = this.timeout,
         maxAge = this.maxAge,
     } = {}) {
-        const breaker = new Breaker(host, { maxFailures, onResponse, maxAge, timeout });
+        const breaker = new Breaker(host, {
+            maxFailures, onResponse, maxAge, timeout,
+        });
         breaker.on('open', (hostname) => {
             this.emit('open', hostname);
         });

--- a/lib/main.js
+++ b/lib/main.js
@@ -23,9 +23,9 @@ const CircuitB = class CircuitB extends EventEmitter {
         super();
 
         assert(Number.isInteger(maxFailures), `Provided value, ${maxFailures}, to argument "maxFailures" is not a number`);
+        assert(utils.isFunction(onResponse), `Provided value to argument "onResponse" is not a function`);
         assert(Number.isInteger(timeout), `Provided value, ${timeout}, to argument "timeout" is not a number`);
         assert(Number.isInteger(maxAge), `Provided value, ${maxAge}, to argument "maxAge" is not a number`);
-        assert(utils.isFunction(onResponse), `Provided value to argument "onResponse" is not a function`);
 
         Object.defineProperty(this, 'registry', {
             value: new Map(),

--- a/lib/response.js
+++ b/lib/response.js
@@ -6,38 +6,38 @@ module.exports = (res = {}) => {
     }
 
     let result = false;
-    switch (res.statusCode){
-        case 408: // Request Timeout
-            result = true;
-            break;
+    switch (res.statusCode) {
+    case 408: // Request Timeout
+        result = true;
+        break;
 
-        case 413: // Payload Too Large
-            result = true;
-            break;
+    case 413: // Payload Too Large
+        result = true;
+        break;
 
-        case 429: // Too Many Requests
-            result = true;
-            break;
+    case 429: // Too Many Requests
+        result = true;
+        break;
 
-        case 500: // Internal Server Error
-            result = true;
-            break;
+    case 500: // Internal Server Error
+        result = true;
+        break;
 
-        case 502: // Bad Gateway
-            result = true;
-            break;
+    case 502: // Bad Gateway
+        result = true;
+        break;
 
-        case 503: // Service Unavailable
-            result = true;
-            break;
+    case 503: // Service Unavailable
+        result = true;
+        break;
 
-        case 504: // Gateway Timeout
-            result = true;
-            break;
+    case 504: // Gateway Timeout
+        result = true;
+        break;
 
-        default:
-            result = false;
+    default:
+        result = false;
     }
 
     return result;
-}
+};

--- a/lib/response.js
+++ b/lib/response.js
@@ -1,0 +1,43 @@
+'use strict';
+
+module.exports = (res = {}) => {
+    if (res.statusCode === undefined) {
+        return true;
+    }
+
+    let result = false;
+    switch (res.statusCode){
+        case 408: // Request Timeout
+            result = true;
+            break;
+
+        case 413: // Payload Too Large
+            result = true;
+            break;
+
+        case 429: // Too Many Requests
+            result = true;
+            break;
+
+        case 500: // Internal Server Error
+            result = true;
+            break;
+
+        case 502: // Bad Gateway
+            result = true;
+            break;
+
+        case 503: // Service Unavailable
+            result = true;
+            break;
+
+        case 504: // Gateway Timeout
+            result = true;
+            break;
+
+        default:
+            result = false;
+    }
+
+    return result;
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isFunction = fn => {
+const isFunction = (fn) => {
     const type = {}.toString.call(fn);
     return type === '[object Function]' || type === '[object AsyncFunction]';
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const isFunction = fn => {
+    const type = {}.toString.call(fn);
+    return type === '[object Function]' || type === '[object AsyncFunction]';
+};
+module.exports.isFunction = isFunction;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:axios": "tape test/integration-axios.js | tap-summary",
     "test:http": "tape test/integration-http.js | tap-summary",
     "test:got": "tape test/integration-got.js | tap-summary",
+    "test:response": "tape test/response.js | tap-summary",
     "test:breaker": "tape test/breaker.js | tap-summary",
     "test:main": "tape test/main.js | tap-summary",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test:got": "tape test/integration-got.js | tap-summary",
     "test:response": "tape test/response.js | tap-summary",
     "test:breaker": "tape test/breaker.js | tap-summary",
+    "test:utils": "tape test/utils.js | tap-summary",
     "test:main": "tape test/main.js | tap-summary",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"

--- a/test/integration-axios.js
+++ b/test/integration-axios.js
@@ -7,6 +7,7 @@ const timeout = require('./integration/timeout');
 const http400 = require('./integration/http-status-400');
 const http500 = require('./integration/http-status-500');
 const errorFlight = require('./integration/error-in-flight');
+const customTripper = require('./integration/custom-tripper');
 
 const client = options => new Promise((resolve) => {
     axios.get(`http://${options.host}:${options.port}/`)
@@ -115,6 +116,21 @@ test('integration - axios - error', async (t) => {
         'circuit breaking',
         'circuit breaking',
         'circuit breaking',
+        'ok',
+        'ok',
+    ]);
+    t.end();
+});
+
+test('integration - axios - custom tripper', async (t) => {
+    const result = await customTripper(client);
+    t.deepEqual(result, [
+        'ok',
+        'ok',
+        'http error',
+        'http error',
+        'http error',
+        'http error',
         'ok',
         'ok',
     ]);

--- a/test/integration-fetch.js
+++ b/test/integration-fetch.js
@@ -7,6 +7,7 @@ const timeout = require('./integration/timeout');
 const http400 = require('./integration/http-status-400');
 const http500 = require('./integration/http-status-500');
 const errorFlight = require('./integration/error-in-flight');
+const customTripper = require('./integration/custom-tripper');
 
 const client = options => new Promise((resolve) => {
     fetch(`http://${options.host}:${options.port}/`)
@@ -117,6 +118,21 @@ test('integration - node-fetch - error', async (t) => {
         'circuit breaking',
         'circuit breaking',
         'circuit breaking',
+        'ok',
+        'ok',
+    ]);
+    t.end();
+});
+
+test('integration - node-fetch - custom tripper', async (t) => {
+    const result = await customTripper(client);
+    t.deepEqual(result, [
+        'ok',
+        'ok',
+        'http error',
+        'http error',
+        'http error',
+        'http error',
         'ok',
         'ok',
     ]);

--- a/test/integration-got.js
+++ b/test/integration-got.js
@@ -9,6 +9,7 @@ const http500 = require('./integration/http-status-500');
 const http500Retry = require('./integration/http-status-500-retry');
 const errorFlight = require('./integration/error-in-flight');
 const errorFlightRetry = require('./integration/error-in-flight-retry');
+const customTripper = require('./integration/custom-tripper');
 
 
 const client = async (options) => {
@@ -123,6 +124,21 @@ test('integration - got - retry: 0 - error', async (t) => {
         'circuit breaking',
         'circuit breaking',
         'circuit breaking',
+        'ok',
+        'ok',
+    ]);
+    t.end();
+});
+
+test('integration - got - retry: 0 - custom tripper', async (t) => {
+    const result = await customTripper(client);
+    t.deepEqual(result, [
+        'ok',
+        'ok',
+        'http error',
+        'http error',
+        'http error',
+        'http error',
         'ok',
         'ok',
     ]);

--- a/test/integration-http.js
+++ b/test/integration-http.js
@@ -8,6 +8,7 @@ const timeout = require('./integration/timeout');
 const http400 = require('./integration/http-status-400');
 const http500 = require('./integration/http-status-500');
 const errorFlight = require('./integration/error-in-flight');
+const customTripper = require('./integration/custom-tripper');
 
 test('before', async (t) => {
     await before();
@@ -107,6 +108,20 @@ test('integration - http.get - error', async (t) => {
     t.end();
 });
 
+test('integration - http.get - custom tripper', async (t) => {
+    const result = await customTripper(clientHttp);
+    t.deepEqual(result, [
+        'ok',
+        'ok',
+        'http error',
+        'http error',
+        'http error',
+        'http error',
+        'ok',
+        'ok',
+    ]);
+    t.end();
+});
 
 test('after', async (t) => {
     await after();

--- a/test/integration-request.js
+++ b/test/integration-request.js
@@ -7,6 +7,7 @@ const timeout = require('./integration/timeout');
 const http400 = require('./integration/http-status-400');
 const http500 = require('./integration/http-status-500');
 const errorFlight = require('./integration/error-in-flight');
+const customTripper = require('./integration/custom-tripper');
 
 const client = options => new Promise((resolve) => {
     const opts = {
@@ -131,6 +132,21 @@ test('integration - request.js - error', async (t) => {
         'circuit breaking',
         'circuit breaking',
         'circuit breaking',
+        'ok',
+        'ok',
+    ]);
+    t.end();
+});
+
+test('integration - request.js - custom tripper', async (t) => {
+    const result = await customTripper(client);
+    t.deepEqual(result, [
+        'ok',
+        'ok',
+        'http error',
+        'http error',
+        'http error',
+        'http error',
         'ok',
         'ok',
     ]);

--- a/test/integration/custom-tripper.js
+++ b/test/integration/custom-tripper.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const CircuitB = require('../../');
+const { server, sleep } = require('../../utils/utils');
+
+const test = async (client) => {
+    const cb = new CircuitB({ maxAge: 200, timeout: 100 });
+    const s = await server({ type: 'code-400', healAt: 6 });
+    const address = s.address();
+
+    cb.set('circuit-b.local', { maxFailures: 4, onResponse: () => {
+            return false;
+        }
+    });
+    cb.enable();
+
+    const options = {
+        host: 'circuit-b.local',
+        port: address.port,
+        timeout: 2000,
+        retry: 0,
+    };
+
+    const result = [];
+
+    // two ok responses, server fails at third request. total 2 request to server
+    result.push(await client(options));
+    result.push(await client(options));
+
+    // four error responses, server failed at third request. circuit breaker is not
+    // responding to these because onResponse is set to not trip on http errors
+    // total 6 request to server
+    result.push(await client(options));
+    result.push(await client(options));
+    result.push(await client(options));
+    result.push(await client(options));
+
+    // circuit breaker is not interfering
+    result.push(await client(options));
+    result.push(await client(options));
+
+    await s.stop();
+    await sleep(20);
+
+    cb.disable();
+    return result;
+};
+
+module.exports = test;

--- a/test/integration/custom-tripper.js
+++ b/test/integration/custom-tripper.js
@@ -8,9 +8,9 @@ const test = async (client) => {
     const s = await server({ type: 'code-400', healAt: 6 });
     const address = s.address();
 
-    cb.set('circuit-b.local', { maxFailures: 4, onResponse: () => {
-            return false;
-        }
+    cb.set('circuit-b.local', {
+        maxFailures: 4,
+        onResponse: () => false,
     });
     cb.enable();
 

--- a/test/integration/error-in-flight-retry.js
+++ b/test/integration/error-in-flight-retry.js
@@ -23,7 +23,8 @@ const test = async (client) => {
     result.push(await client(options));
     result.push(await client(options));
 
-    // two error responses which is a total of 6 requests to server, server failed at third request. total 8 request to server
+    // two error responses which is a total of 6 requests to server,
+    // server failed at third request. total 8 request to server
     result.push(await client(options));
     result.push(await client(options));
 

--- a/test/integration/http-status-500-retry.js
+++ b/test/integration/http-status-500-retry.js
@@ -23,7 +23,8 @@ const test = async (client) => {
     result.push(await client(options));
     result.push(await client(options));
 
-    // two error responses which is a total of 6 requests to server, server failed at third request. total 8 request to server
+    // two error responses which is a total of 6 requests to server,
+    // server failed at third request. total 8 request to server
     result.push(await client(options));
     result.push(await client(options));
 

--- a/test/main.js
+++ b/test/main.js
@@ -21,6 +21,14 @@ test('CircuitB() - "maxFailures" argument is not a number - should throw', (t) =
     t.end();
 });
 
+test('CircuitB() - "onResponse" argument is not a function - should throw', (t) => {
+    t.plan(1);
+    t.throws(() => {
+        const cb = new CircuitB({ onResponse: 'foo' }); // eslint-disable-line no-unused-vars
+    }, /Provided value to argument "onResponse" is not a function/);
+    t.end();
+});
+
 test('CircuitB() - "maxAge" argument is not a number - should throw', (t) => {
     t.throws(() => {
         const cb = new CircuitB({ maxAge: 'foo' }); // eslint-disable-line no-unused-vars
@@ -53,6 +61,15 @@ test('.set() - "maxFailures" argument is not a number - should throw', (t) => {
         const cb = new CircuitB();
         cb.set('circuit-b.local', { maxFailures: 'foo' });
     }, /Provided value, foo, to argument "maxFailures" is not a number/);
+    t.end();
+});
+
+test('.set() - "onResponse" argument is not a function - should throw', (t) => {
+    t.plan(1);
+    t.throws(() => {
+        const cb = new CircuitB();
+        cb.set('circuit-b.local', { onResponse: 'foo' });
+    }, /Provided value to argument "onResponse" is not a function/);
     t.end();
 });
 

--- a/test/response.js
+++ b/test/response.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const test = require('tape');
+const response = require('../lib/response');
+
+test('response() - no "res" argument - should return "true"', (t) => {
+    const result = response();
+    t.true(result);
+    t.end();
+});
+
+test('response() - "res" has no ".statusCode" parameter - should return "true"', (t) => {
+    const result = response({ foo : 'bar' });
+    t.true(result);
+    t.end();
+});
+
+test('response() - "res" has ".statusCode" parameter - should return "true" on 408, 413, 429, 500, 502, 503 and 504', (t) => {
+    const result = [];
+    for (let i = 100; i < 600; i++) {
+        if (response({ statusCode : i })) {
+            result.push(i);
+        }
+
+    }
+
+    t.deepEqual(result, [
+        408,
+        413,
+        429,
+        500,
+        502,
+        503,
+        504,
+    ]);
+
+    t.end();
+});

--- a/test/response.js
+++ b/test/response.js
@@ -10,18 +10,17 @@ test('response() - no "res" argument - should return "true"', (t) => {
 });
 
 test('response() - "res" has no ".statusCode" parameter - should return "true"', (t) => {
-    const result = response({ foo : 'bar' });
+    const result = response({ foo: 'bar' });
     t.true(result);
     t.end();
 });
 
 test('response() - "res" has ".statusCode" parameter - should return "true" on 408, 413, 429, 500, 502, 503 and 504', (t) => {
     const result = [];
-    for (let i = 100; i < 600; i++) {
-        if (response({ statusCode : i })) {
+    for (let i = 100; i < 600; i += 1) {
+        if (response({ statusCode: i })) {
             result.push(i);
         }
-
     }
 
     t.deepEqual(result, [

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const test = require('tape');
+const utils = require('../lib/utils');
+
+/**
+ * .isFunction()
+ */
+
+test('.isFunction() - no arguments given - should return false', (t) => {
+    const result = utils.isFunction();
+    t.false(result);
+    t.end();
+});
+
+test('.isFunction() - arguments is an object - should return false', (t) => {
+    const result = utils.isFunction({});
+    t.false(result);
+    t.end();
+});
+
+test('.isFunction() - arguments is an string - should return false', (t) => {
+    const result = utils.isFunction('function');
+    t.false(result);
+    t.end();
+});
+
+test('.isFunction() - arguments is an array - should return false', (t) => {
+    const result = utils.isFunction([]);
+    t.false(result);
+    t.end();
+});
+
+test('.isFunction() - arguments is an boolean - should return false', (t) => {
+    const result = utils.isFunction(true);
+    t.false(result);
+    t.end();
+});
+
+test('.isFunction() - arguments is an number - should return false', (t) => {
+    const result = utils.isFunction(42);
+    t.false(result);
+    t.end();
+});
+
+test('.isFunction() - arguments is an function - should return true', (t) => {
+    const result = utils.isFunction(() => {});
+    t.true(result);
+    t.end();
+});
+
+test('.isFunction() - arguments is an arrow function - should return true', (t) => {
+    const result = utils.isFunction(() => {});
+    t.true(result);
+    t.end();
+});
+
+test('.isFunction() - arguments is an async function - should return true', (t) => {
+    const result = utils.isFunction(async () => {});
+    t.true(result);
+    t.end();
+});

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -10,7 +10,7 @@ const server = ({ failAt = 3, healAt = 10, type = 'code-500' } = {}) => new Prom
         counter += 1;
         if (counter >= failAt && counter <= healAt) {
             if (type === 'code-400') {
-                res.writeHead(400, { 'Content-Type': 'text/plain' });
+                res.writeHead(429, { 'Content-Type': 'text/plain' });
                 res.end('error');
             }
             if (type === 'code-500') {


### PR DESCRIPTION
Refines the breaker to trip only on the following http status codes:

 - 408
 - 413
 - 429
 - 500
 - 502
 - 503
 - 504

This also ads a `onResponse` feature where its possible to append a function which can be used for custom tailoring what the breaker should trip on during a response. By providing such a custom function it will override the built in tripping on the above status codes.

The `onResponse` feature can be set globaly for all hosts or pr single host.